### PR TITLE
Fix Python syntax error

### DIFF
--- a/codecademySQL.py
+++ b/codecademySQL.py
@@ -49,6 +49,6 @@ purchases.to_sql('purchases', conn, dtype={
 def sql_query(query):
     try:
         df = pd.read_sql(query, conn)
-    except e:
+    except Exception as e:
         print (e.message)
     return df


### PR DESCRIPTION
```
>>> try:
...     "bob".bob()
... except e:
...     print(e)
...
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
AttributeError: 'str' object has no attribute 'bob'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
NameError: name 'e' is not defined
```